### PR TITLE
Updates for Zig 0.12 and 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 zig-cache/
+.zig-cache/
 zig-out/
 /release/
 /debug/

--- a/build.zig
+++ b/build.zig
@@ -5,16 +5,16 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     _ = b.addModule("cycleclock", .{
-        .root_source_file = .{ .path = "src/cycleclock.zig" },
+        .root_source_file = b.path("src/cycleclock.zig"),
     });
 
     const lib_unit_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/cycleclock.zig" },
+        .root_source_file = b.path("src/cycleclock.zig"),
         .target = target,
         .optimize = optimize,
         .link_libc = true,
     });
-    lib_unit_tests.addIncludePath(.{ .path = "src" });
+    lib_unit_tests.addIncludePath(b.path("src"));
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
     const test_step = b.step("test", "Run unit tests");


### PR DESCRIPTION
I'm not sure what version(s) of Zig are intended to be supported, but some minor changes to the `build.zig` will make this package compatible with the versions of Zig since 0.12.0.

Summary of changes:

  - use of `std.Build.path()`
The utility function `std.Build.path()` was introduced in zig version `0.11.0-dev.3632+7fb5a0b1`, so this PR breaks compatibility with versions of zig prior to that. The use of `std.Build.path()` is required for zig versions since `0.12.0-dev.76+dee9f82f`.

   - updated `.gitignore`
Between Zig 0.12 and Zig 0.13 the default local cache was switched to `.zig-cache/`. Leaving `zig-cache/` in the ignore list is helpful if using Zig 0.12, but otherwise it could be removed.